### PR TITLE
👷 Monthly actions version update

### DIFF
--- a/.github/workflows/repo-actions_updater.yml
+++ b/.github/workflows/repo-actions_updater.yml
@@ -12,7 +12,7 @@ jobs:
     # saadmk11/github doesn't work on Self hosted runner yet 
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4.1.1
+            - uses: actions/checkout@v7.0.0
               with:
                 # Classic personal access token with repo and workflow scope
                 token: ${{ secrets.REPO_WORKFLOW_ACCESS_TOKEN }} 

--- a/action.yml
+++ b/action.yml
@@ -68,7 +68,7 @@ runs:
   - name: Find Slack user based on the emails
     if: env.slack_user_email_found == 'true'
     id: find_slack_user
-    uses: scribd/find-slack-user-action@v1.0.4
+    uses: scribd/find-slack-user-action@v1.0.5
     with:
       slack-token: ${{ inputs.SLACK_API_TOKEN }}
       email: ${{ env.slack_user_email }}
@@ -89,7 +89,7 @@ runs:
 
   - name: Slack notification
     if: env.slack_user_email_found == 'true'
-    uses: 8398a7/action-slack@v3
+    uses: 8398a7/action-slack@v3.19.0
     with:
       status: custom
       custom_payload: |


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[scribd/find-slack-user-action](https://github.com/scribd/find-slack-user-action)** published a new release **[v1.0.5](https://github.com/scribd/find-slack-user-action/releases/tag/v1.0.5)** on 2026-04-03T19:33:53Z
* **[8398a7/action-slack](https://github.com/8398a7/action-slack)** published a new release **[v3.19.0](https://github.com/8398a7/action-slack/releases/tag/v3.19.0)** on 2025-09-13T12:57:32Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v7.0.0](https://github.com/actions/checkout/releases/tag/v7.0.0)** on 2026-06-18T13:53:05Z
